### PR TITLE
(add) 2023 contest info

### DIFF
--- a/content/contests/summer-2023.md
+++ b/content/contests/summer-2023.md
@@ -1,0 +1,60 @@
+---
+new_layout: true
+new_timeline: true
+tabs:
+  - rules
+  - speakers
+  - registration
+  - prizes
+  - example
+  - sponsors
+title: Summer 2023 Virtual Programming Contest
+date: '2023-08-12'
+time: '9:15 AM - 3:30 PM Pacific Time'
+status: Upcoming 
+place: Youtube Live
+image: /images/contests/virtual-contest.webp
+description: 'TeamsCode Summer 2023 Online Programming Contest will take place on Saturday, August 12th, from 9:15 AM to 3:30 PM (Pacific Time) through a Youtube livestream! Computer science students are welcomed to join this competitive programming experience! Teams of up to 4 students will spend 3 hours solving interesting algorithmic problems. There will be two divisions: Novice and Advanced. Prizes will be given out, including placement awards, raffle prizes, and more! Only pre-college participants are eligible for prizes.'
+timeline:
+  -
+    - '2023-08-12 09:15:00'
+    - '2023-08-12 09:45:00'
+    - 'Opening Ceremony and Rule Review'
+    - 'Join us at Youtube Livestream to watch the opening ceremony. We will also be going over the rules of the contest.'
+  -
+    - '2023-08-12 09:45:00'
+    - '2023-08-12 12:45:00'
+    - 'Coding time! Last submission by 12:45 PM'
+    - 'Login to TeamsCode Contest Portal and start coding! All team members can submit solutions and get instant feedbacks until 12:45 PM.'
+  -
+    - '2023-08-12 12:45:00'
+    - '2023-08-12 13:00:00'
+    - 'Lunch Break'
+    - 'Please take a short break while we get ready for the speaker events. If you need, feel free to eat lunch while listening to the speakers.'
+  -
+    - '2023-08-12 13:00:00'
+    - '2023-08-12 14:00:00'
+    - 'Guest Speaker Event'
+  -
+    - '2023-08-12 14:00:00'
+    - '2023-08-12 15:00:00'
+    - 'Guest Speaker Event'
+  -
+    - '2023-08-12 15:00:00'
+    - '2023-08-12 15:30:00'
+    - 'Raffle, Contest Winners Announcement, and Closing Ceremony'
+    - 'Tune in to our Youtube Livestream to watch the winners announcement, raffle, and our final closing ceremony.'
+cards:
+  -
+    - 'Contest Duration'
+    - '3 Hours'
+  -
+    - 'Coding Languages'
+    - 'C++/Python/Java'
+  -
+    - 'Team Size'
+    - '4 people'
+  -
+    - 'Divisions'
+    - 'Novice/Advanced'
+---

--- a/content/contests/summer-2023.md
+++ b/content/contests/summer-2023.md
@@ -34,11 +34,13 @@ timeline:
   -
     - '2023-08-12 13:00:00'
     - '2023-08-12 14:00:00'
-    - 'Guest Speaker Event'
+    - 'Guest Speaker Event - Mr. Michael Plunkett'
+    - 'Michael Plunkett is an experienced software engineer of 10+ years and a second-year graduate student at the Harris School of Public Policy at the University of Chicago.'
   -
     - '2023-08-12 14:00:00'
     - '2023-08-12 15:00:00'
     - 'Guest Speaker Event'
+    - 'We are still finalizing our second speaker. Updates coming soon!'
   -
     - '2023-08-12 15:00:00'
     - '2023-08-12 15:30:00'

--- a/content/contests/summer-2023/example.md
+++ b/content/contests/summer-2023/example.md
@@ -1,0 +1,59 @@
+---
+slug: example
+name: Example Problem
+---
+
+## Example Problem
+
+#### Summer 2021 Novice 3, Lattice Flowers
+
+<br>
+
+Goma was busy picking flowers for Peach when he discovered a patch of flowers in the form of an NxM lattice with one flower per point. Starting from point (1,1) of the lattice, Goma will walk in a straight line picking up all flowers in the points he passes through (including (1,1)). He wants to find a path to maximize the number of flowers he picks, and he also wants to know the number of ways to walk that will maximize the number of flowers he picks up.
+
+### Input
+
+You will answer T test cases (1≤T≤10) where each test case is: two integers N, M (2≤N,M≤1000), the dimensions of the grid.
+
+The first line of the input will be T, followed by T lines with two integers each N and M respectively.
+
+### Output
+
+Two integers a and b where a is the maximum amount of flowers that can be picked up by Goma starting from (1,1) and b is the number of unique ways he can walk to pick up flowers starting from point (1,1).
+
+### Sample Input
+
+```
+2
+2 2
+3 2
+```
+
+<br>
+
+### Sample Output
+
+```
+2 3
+3 1
+```
+
+<br>
+
+### Sample Explanation
+
+In the first test case, Goma can pick up two flowers at most, and he can walk from (1,1) to (2,1); (1,1) to (2,2); and from (1,1) to (1,2) to pick up his 2 flowers
+
+In the second test case, it can be proven that Goma can only pick up 3 flowers at best, walking from (1,1) to (3,1).
+
+### Think you've solved it?
+
+* Submit the problem
+  * Here: <https://codeforces.com/gym/103241/problem/C>
+  * You will need to make a codeforces account: <https://codeforces.com/register>
+* Solution explanation
+  * <https://github.com/chessbot108/tc_edi/blob/main/teamscode_summer_2021_editorial_full.pdf>
+* Model solution
+  * <https://github.com/chessbot108/tc_edi/blob/main/latticeflowers/model.cpp>
+* Try more problems from the last contest
+  * <https://codeforces.com/gym/103241>

--- a/content/contests/summer-2023/prizes.md
+++ b/content/contests/summer-2023/prizes.md
@@ -1,0 +1,26 @@
+---
+slug: prizes
+name: Prizes
+---
+
+## Contest Prizes
+
+* Win up to $100 by competing in the Advanced division! More prizes from our sponsors will be added to the list soon (see Spring 2023 for reference). Stay tuned for our announcements!
+* The top 5 scoring teams from each division will win amazon gift cards. The growing list of prizes each team member will win:
+  <br>**Advanced Prizes per team member**
+  * **1st** - $100 Amazon Giftcard
+  * **2nd** - $50 Amazon Giftcard
+  * **3rd** - $40 Amazon Giftcard
+  * **4th** - $30 Amazon Giftcard
+  * **5th** - $20 Amazon Giftcard
+  **Novice Prizes per team member**
+  * **1st** - $30 Amazon Giftcard
+  * **2nd** - $20 Amazon Giftcard
+  * **3rd** - $10 Amazon Giftcard
+  * **4th** - $10 Amazon Giftcard
+  * **5th** - $10 Amazon Giftcard
+* When you submit your first submission, each member in your team will receive 1 raffle ticket.
+* Raffle prizes will be drawn in the last half hour of the contest using a random number generator - we will email those selected for shipment details immediately following the contest.
+* The raffle prizes are listed below:
+  * 1x Logitech G PRO Mechanical Gaming Keyboard
+  * 1x Apple Airpods 3rd Generation

--- a/content/contests/summer-2023/registration.md
+++ b/content/contests/summer-2023/registration.md
@@ -1,0 +1,22 @@
+---
+slug: registration
+name: Registration
+---
+
+## Registration Instructions
+
+Welcome to TeamsCode contests! Each team will only need one account on TeamsCode Contest Portal to participate, and we recommend the team captain to register for your team. Before getting started, make sure you have confirmed the following with your team:
+
+* A team name, be creative and keep it appropriate.
+* A username, this will be your unique login handler.
+* A team password, this password will be shared among all team members.
+* The name, email, their parent's email, and high school graduation year of each team member. If any team member has graduated from high school, simply put the year they graduated in the high school graduation year field.
+
+<br>Once you have these information, you can begin creating an account by following the below instructions.
+
+1. Click on the "**Register Now**" button on top of this section. You will be guided to our Contest Portal and a registration window will pop up automatically.
+2. Fill in the information about your team, all field are required. Team member 1 will be treated as the **team captain**. All teammates will receive the team password, so please use something that you are comfortable sharing with the rest of the team.
+3. Click register!
+4. Once you successful registered an account, all team members will receive a confirmation email at their inbox. The confirmation email will contain your team username and password. Please also check your promotion and spam folder if you couldn't find the email.
+
+<br>You are all set! Save the contest date in your calendar and remember to submit at least one solution to be eligible for raffle!

--- a/content/contests/summer-2023/rules.md
+++ b/content/contests/summer-2023/rules.md
@@ -1,0 +1,69 @@
+---
+slug: rules
+name: Rules
+---
+
+## General Rules
+
+* Only teams with only middle or high school students (rising 6th - senior) are eligible for prizes, however everyone (college students, workers) is welcome to compete.
+* Each team may have up to 4 people. Team members may not receive any help from anyone outside of their team.
+* Teams must submit at least once to be eligible for raffle prizes.
+* Teams may use multiple computers and submit answers in multiple languages.
+* Pre-written code and online reference guides are allowed (in other words, internet is allowed so long as you’re not asking people how to solve our problem).
+* We reserve the right to disqualify participants who intentionally participate in divisions with problem difficulties that are too low for the skill level of the participant. For example, USACO finalists and International Masters on Codeforces cannot participate in the Novice division. We do not tolerate those who attempt to undermine the fairness of the competition.
+* There are two divisions: **Novice** and **Advanced**. We expect each division will be interesting for participants of the following skill levels:
+  * The novice division is intended for students who know programming but have not started or have just started competitive programming:
+    * Taking or have taken APCS
+    * USACO Bronze-Silver
+    * 0 - 1500 Codeforces rating
+  * The advanced division is intended for anyone who is confident in their competitive programming ability:
+    * USACO Gold and above
+    * 1600+ Codeforces rating
+* Contest page: [https://summer23.teamscode.org](https://summer23.teamscode.org)
+* Join our discord server here: [https://go.teamscode.org/discord](https://go.teamscode.org/discord) for important contest announcements or if you have any questions.
+* Try more problems from the last contest:
+  * [CodeForces Gym](https://codeforces.com/gym/104287)
+  * You will need to make a codeforces account: <https://codeforces.com/register>
+
+## Problem Format
+
+* Description: an overview of the problem.
+* Input Format: specifies how the input will be formatted, including constraints on the size of parameters. (constraints may be stated in the Description).
+* Output Format: specifies how the output should be formatted - if you don’t follow this format exactly, your answer will most likely be marked as incorrect.
+* Sample Input: provides a sample input to help you test your code.
+* Sample Output: provides the expected output to the sample input.
+* Sample Explanation: provides an explanation of how the sample output was obtained from the sample input.
+
+## Submitting Solutions
+
+* Allowed Languages: C++, C, Java, Python 2, Python 3
+* Solutions will be submitted through the contest page listed above. The code for each problem should be copy-pasted into the box that appears after clicking “Submit Code”.
+* For Java submissions, the class name of your main function must be ```Main```.
+* The file size containing your code must not exceed 50 KB.
+* Default Constraints
+  * Note that constraints may vary depending on the problem.
+  * Time Limit: Your program must run in under 2,000 ms (2 seconds) for C and C++, under 4,000 ms (4 seconds) for Java, and under 8,000 ms (8 seconds) for Python.  Time limits for each language may be different if specified in a problem.
+  * Memory Limit: The program's memory must not exceed 256 MB
+* Use **Standard Input** in your code. This means that test cases are directly typed into the console. Here’s an example for each of the allowed languages:<br>**Java:** `Scanner(System.in)`  **C++:** `cin>>` **Python:** `input()`    **C:** `scanf()`
+* Use **Standard Output** in your code. This means that the output directly prints to the console. Here’s what standard output looks like for each of the languages:<br>**Java:** `System.out.println()`  **C++:** `cout<<` **Python:** `print()` **C:** `printf()`
+
+## Scoring
+
+### Problem Difficulty
+
+* There are ~10 total problems in ascending order of difficulty.
+
+### Problem Points
+
+* All problems are each worth 100 points. Each problem has some number of tests (usually 10 or 20). Sample test is worth 0 point. If you solve X non-sample tests correctly for a problem with Y non-sample tests, you get (X/Y * 100) points.
+* Note that each test may have multiple test cases where each test case must be solved correctly to get points for the test.
+* Output must match **exactly** with expected output to receive points for the test case - there is no partial credit.
+
+### Problem Tests
+
+* The first test is always the sample given in the problem.
+* Some problems will have explicitly stated subtasks. For example, a problem with 10 tests may have tests 1-5 with N<=10 and tests 6-10 with N<=100.
+
+### Ties
+
+* Ties will be broken by the timestamp on the last submission that increases your total score.

--- a/content/contests/summer-2023/speakers.md
+++ b/content/contests/summer-2023/speakers.md
@@ -3,4 +3,8 @@ slug: speakers
 name: Guest Speakers
 ---
 
-## Update Comming Soon
+## Mr. Michael Plunkett
+
+<br>
+
+Michael Plunkett is an experienced software engineer of 10+ years and a second-year graduate student at the Harris School of Public Policy at the University of Chicago. At the University of Chicago, he is pursuing a Master of Science in Computational Analysis and Public Policy, a joint degree between the public policy and computer science schools. He left the software engineering industry in the Fall of 2022 to return to school to apply his technical skills in the areas he is particularly passionate about, specifically police accountability, alternatives to policing, reproductive rights, and voting equity. In his off-time, he likes to read sci-fi, consume far too much of the New Yorker, and work his way up and down Chicago's Lakeside Drive while running or biking.

--- a/content/contests/summer-2023/speakers.md
+++ b/content/contests/summer-2023/speakers.md
@@ -1,0 +1,6 @@
+---
+slug: speakers
+name: Guest Speakers
+---
+
+## Update Comming Soon

--- a/content/contests/summer-2023/sponsors.md
+++ b/content/contests/summer-2023/sponsors.md
@@ -1,6 +1,7 @@
 ---
 slug: sponsors
 name: Sponsors
+disabled: True
 ---
 
 ## Update Comming Soon!

--- a/content/contests/summer-2023/sponsors.md
+++ b/content/contests/summer-2023/sponsors.md
@@ -1,0 +1,6 @@
+---
+slug: sponsors
+name: Sponsors
+---
+
+## Update Comming Soon!

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,14 +15,14 @@
 
         <v-spacer />
 
-        <!--div v-if="$vuetify.breakpoint.mdAndUp&&!$route.path.startsWith('/contests/spring-2023')" class="mr-2 text-subtitle-1">
-          Spring 2023 programming contest is open to registration!
+        <div v-if="$vuetify.breakpoint.mdAndUp&&!$route.path.startsWith('/contests/summer-2023')" class="mr-2 text-subtitle-1">
+          The Summer 2023 Programming Contest is now accepting registrations!
         </div>
-        <v-btn v-if="$vuetify.breakpoint.mdAndUp&&!$route.path.startsWith('/contests/spring-2023')" color="primary" to="/contests/spring-2023" class="mr-1">
+        <v-btn v-if="$vuetify.breakpoint.mdAndUp&&!$route.path.startsWith('/contests/summer-2023')" color="primary" to="/contests/summer-2023" class="mr-1">
           Register Now<v-icon right>
             {{ mdiArrowRight }}
           </v-icon>
-        </v-btn-->
+        </v-btn>
       </v-container>
 
       <template #extension>
@@ -188,15 +188,15 @@
           </v-list-item-content>
         </v-list-item>
       </v-list>
-      <!--template #append>
+      <template #append>
         <div class="pa-2">
-          <v-btn v-if="!$route.path.startsWith('/contests/spring-2023')" color="primary" to="/contests/spring-2023" class="mr-3">
+          <v-btn v-if="!$route.path.startsWith('/contests/summer-2023')" color="primary" to="/contests/summer-2023" class="mr-3">
             Upcoming Contest<v-icon right>
               {{ mdiArrowRight }}
             </v-icon>
           </v-btn>
         </div>
-      </template-->
+      </template>
     </v-navigation-drawer>
   </v-app>
 </template>

--- a/pages/contests/_slug.vue
+++ b/pages/contests/_slug.vue
@@ -4,8 +4,7 @@
       v-if="content.status==='Upcoming'"
       class="reg-button d-md-flex d-none"
       color="primary"
-      disabled
-      href="https://spring23.teamscode.org/?register=direct"
+      href="https://summer23.teamscode.org/?register=direct"
       target="_blank"
       elevation="24"
       large
@@ -14,10 +13,9 @@
     </v-btn>
     <v-btn
       v-if="content.status==='Upcoming'"
-      disabled
       class="reg-button-tablet d-sm-flex d-md-none d-none"
       color="primary"
-      href="https://spring23.teamscode.org/?register=direct"
+      href="https://summer23.teamscode.org/?register=direct"
       target="_blank"
       elevation="24"
       large
@@ -27,10 +25,9 @@
     <v-container class="reg-button-mobile d-sm-none d-flex px-4">
       <v-btn
         v-if="content.status==='Upcoming'"
-        disabled
         block
         color="primary"
-        href="https://spring23.teamscode.org/?register=direct"
+        href="https://summer23.teamscode.org/?register=direct"
         target="_blank"
         elevation="24"
         large

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,16 +11,16 @@
               Participate in TeamsCode Team Programming contests to challenge yourself with some inspiring competitive programming problems while having fun with your friends.
             </h2>
             <h2 class="text-body-1 mt-4 secondary--text">
-              Spring 2023 winners have been announced! Check out the contests we organized in the past 6 years.
+              Our upcoming contest is almost here! Hit the button below to discover the prizes up for grabs.
             </h2>
             <div class="mt-4">
               <v-btn
                 x-large
                 class="my-1 mr-sm-1 w-full w-sm-auto"
                 color="primary"
-                to="/contests"
+                to="/contests/summer-2023"
               >
-                Browse Contests
+                Summer 2023 Contest
               </v-btn>
               <v-btn
                 x-large

--- a/yarn.lock
+++ b/yarn.lock
@@ -3377,9 +3377,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001400:
-  version "1.0.30001415"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz#fd7ea96e9e94c181a7f56e7571efb43d92b860cc"
-  integrity sha512-ER+PfgCJUe8BqunLGWd/1EY4g8AzQcsDAVzdtMGKVtQEmKAwaFfU6vb7EAVIqTMYsqxBorYZi2+22Iouj/y7GQ==
+  version "1.0.30001517"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz"
+  integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Added Summer 2023 Contest Info.

Issues:
- No Guest Speaker Info
- No Sponsor Info
- I could not figure out how to change the "contest-website" button to redirect to "summer23.teamscode.org" through the markdown files.